### PR TITLE
feat: 회원가입 기능 구현 및 User 엔티티 생성

### DIFF
--- a/src/main/java/com/myjourneylog/config/SecurityConfig.java
+++ b/src/main/java/com/myjourneylog/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.myjourneylog.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authz -> authz
+                        .requestMatchers(
+                                "/login",          // 로그인 페이지
+                                "/signup",
+                                "/api/v1/users/signup",         // 회원가입 페이지
+                                "/css/**",         // 정적리소스(css)
+                                "/js/**",          // 정적리소스(js)
+                                "/images/**"       // 정적리소스(images)
+                        ).permitAll()
+                        .anyRequest().authenticated() // 그 외에는 인증 필요
+                )
+                .formLogin(form -> form
+                        .loginPage("/login")
+                        .permitAll()
+                )
+                .logout(logout -> logout.permitAll());
+        return http.build();
+    }
+}

--- a/src/main/java/com/myjourneylog/controller/UserController.java
+++ b/src/main/java/com/myjourneylog/controller/UserController.java
@@ -1,0 +1,21 @@
+package com.myjourneylog.controller;
+
+import com.myjourneylog.dto.UserSignupRequest;
+import com.myjourneylog.domain.User;
+import com.myjourneylog.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@RequestBody UserSignupRequest request) {
+        userService.signup(request);
+        return ResponseEntity.ok("회원가입 성공");
+    }
+}

--- a/src/main/java/com/myjourneylog/domain/User.java
+++ b/src/main/java/com/myjourneylog/domain/User.java
@@ -1,0 +1,24 @@
+package com.myjourneylog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class User {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    private String profileImgUrl;
+    private String bio;
+}

--- a/src/main/java/com/myjourneylog/dto/UserSignupRequest.java
+++ b/src/main/java/com/myjourneylog/dto/UserSignupRequest.java
@@ -1,0 +1,13 @@
+package com.myjourneylog.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class UserSignupRequest {
+    private String email;
+    private String password;
+    private String nickname;
+    private String profileImgUrl;
+    private String bio;
+}

--- a/src/main/java/com/myjourneylog/repository/UserRepository.java
+++ b/src/main/java/com/myjourneylog/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.myjourneylog.repository;
+
+import com.myjourneylog.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/myjourneylog/service/UserService.java
+++ b/src/main/java/com/myjourneylog/service/UserService.java
@@ -1,0 +1,37 @@
+package com.myjourneylog.service;
+
+import com.myjourneylog.domain.User;
+import com.myjourneylog.dto.UserSignupRequest;
+import com.myjourneylog.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public User signup(UserSignupRequest req) {
+        // 이메일/닉네임 중복체크
+        if (userRepository.existsByEmail(req.getEmail())) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
+        if (userRepository.existsByNickname(req.getNickname())) {
+            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+        }
+        // 비밀번호 암호화
+        String encodedPwd = passwordEncoder.encode(req.getPassword());
+
+        User user = User.builder()
+                .email(req.getEmail())
+                .password(encodedPwd)
+                .nickname(req.getNickname())
+                .profileImgUrl(req.getProfileImgUrl())
+                .bio(req.getBio())
+                .build();
+
+        return userRepository.save(user);
+    }
+}


### PR DESCRIPTION
#1 
## 구현 내용
- 회원가입 API 구현 (POST /api/v1/users/signup)
- User 엔티티, UserRepository, UserService, UserController 생성
- 비밀번호 암호화 적용 (BCrypt)
- Postman 및 curl로 회원가입 성공 확인

## 참고 사항
- 현재 로그인 및 인증/인가 기능 미구현 (이후 추가 예정)
- DB 연결 및 도커 환경에서 정상 동작 확인
