### PR TITLE
feat: 사용자 로그인 및 회원정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/myjourneylog/config/SecurityConfig.java
+++ b/src/main/java/com/myjourneylog/config/SecurityConfig.java
@@ -20,20 +20,16 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers(
-                                "/login",          // 로그인 페이지
-                                "/signup",
-                                "/api/v1/users/signup",         // 회원가입 페이지
-                                "/css/**",         // 정적리소스(css)
-                                "/js/**",          // 정적리소스(js)
-                                "/images/**"       // 정적리소스(images)
+                                "/login",
+                                "/api/v1/users/signup",
+                                "/css/**", "/js/**", "/images/**"
                         ).permitAll()
-                        .anyRequest().authenticated() // 그 외에는 인증 필요
+                        .anyRequest().authenticated()
                 )
                 .formLogin(form -> form
                         .loginPage("/login")
                         .permitAll()
-                )
-                .logout(logout -> logout.permitAll());
+                );
         return http.build();
     }
 }

--- a/src/main/java/com/myjourneylog/controller/UserController.java
+++ b/src/main/java/com/myjourneylog/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.myjourneylog.controller;
 
 import com.myjourneylog.dto.UserSignupRequest;
-import com.myjourneylog.domain.User;
+import com.myjourneylog.dto.UserUpdateRequest;
 import com.myjourneylog.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,5 +17,10 @@ public class UserController {
     public ResponseEntity<String> signup(@RequestBody UserSignupRequest request) {
         userService.signup(request);
         return ResponseEntity.ok("회원가입 성공");
+    }
+    @PatchMapping("/me")
+    public ResponseEntity<String> updateProfile(@RequestBody UserUpdateRequest request) {
+        userService.updateProfile(request);
+        return ResponseEntity.ok("회원 정보 수정 성공");
     }
 }

--- a/src/main/java/com/myjourneylog/dto/LoginRequest.java
+++ b/src/main/java/com/myjourneylog/dto/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.myjourneylog.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/myjourneylog/dto/UserUpdateRequest.java
+++ b/src/main/java/com/myjourneylog/dto/UserUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.myjourneylog.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class UserUpdateRequest {
+    private String nickname;
+    private String profileImgUrl;
+    private String bio;
+}

--- a/src/main/java/com/myjourneylog/security/CustomUserDetails.java
+++ b/src/main/java/com/myjourneylog/security/CustomUserDetails.java
@@ -1,0 +1,43 @@
+package com.myjourneylog.security;
+
+import com.myjourneylog.domain.User;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+
+    public User getUser() { return user; }
+}

--- a/src/main/java/com/myjourneylog/security/CustomUserDetailsService.java
+++ b/src/main/java/com/myjourneylog/security/CustomUserDetailsService.java
@@ -1,0 +1,22 @@
+package com.myjourneylog.security;
+
+import com.myjourneylog.domain.User;
+import com.myjourneylog.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,4 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.springframework.security=DEBUG


### PR DESCRIPTION
#2 
## 개요
- 이메일/비밀번호 기반 로그인(Spring Security)
- 회원정보 수정(닉네임, 프로필이미지, 자기소개) 기능 구현

## 주요 변경점
- POST /login: 이메일+비밀번호 로그인 (세션 인증)
- PATCH /api/v1/users/me: 본인 정보 수정 가능 (닉네임, 프로필이미지, bio)
- 인증된 사용자만 회원정보 수정 가능
- 인증 방식: Spring Security 세션 기반

## 테스트
- Postman으로 로그인/회원정보 수정 모두 정상 동작 확인
- 예외 상황(비로그인 시, 잘못된 정보 등) 테스트