### PR TITLE
feat: 챗봇이 추천해준 코스를 사용자에게 제공, 사용자가 선택한 코스를 DB Course 저장

### DIFF
--- a/backend/src/main/java/com/myjourneylog/MyJourneyLogApplication.java
+++ b/backend/src/main/java/com/myjourneylog/MyJourneyLogApplication.java
@@ -2,8 +2,10 @@ package com.myjourneylog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
+@EnableJpaRepositories
 public class MyJourneyLogApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/myjourneylog/config/SecurityConfig.java
+++ b/backend/src/main/java/com/myjourneylog/config/SecurityConfig.java
@@ -23,6 +23,7 @@ public class SecurityConfig {
                                 "/login",
                                 "/api/v1/users/signup",
                                 "/api/v1/places/**",
+                                "/api/v1/course/**",
                                 "/css/**", "/js/**", "/images/**",
                                 "/chatbot"
                         ).permitAll()

--- a/backend/src/main/java/com/myjourneylog/controller/ChatbotController.java
+++ b/backend/src/main/java/com/myjourneylog/controller/ChatbotController.java
@@ -1,9 +1,9 @@
 package com.myjourneylog.controller;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.myjourneylog.dto.ChatbotRequest;
-import com.myjourneylog.dto.ChatbotResponse;
+import com.myjourneylog.dto.CourseDTO;
 import com.myjourneylog.service.ChatbotService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,17 +11,14 @@ import java.util.List;
 
 
 @RestController
+@RequiredArgsConstructor
 public class ChatbotController {
 
     private final ChatbotService chatbotService;
 
-    public ChatbotController(ChatbotService chatbotService) {
-        this.chatbotService = chatbotService;
-    }
-
     @PostMapping("/chatbot")
-    public ResponseEntity<List<ChatbotResponse>> generateText(@RequestBody ChatbotRequest request) {
-        List<ChatbotResponse> generatedText = chatbotService.getText(request);
+    public ResponseEntity<List<CourseDTO>> generateText(@RequestBody ChatbotRequest request) {
+        List<CourseDTO> generatedText = chatbotService.getText(request);
         return ResponseEntity.ok(generatedText);
     }
 }

--- a/backend/src/main/java/com/myjourneylog/controller/ChatbotController.java
+++ b/backend/src/main/java/com/myjourneylog/controller/ChatbotController.java
@@ -1,9 +1,13 @@
 package com.myjourneylog.controller;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.myjourneylog.dto.ChatbotRequest;
+import com.myjourneylog.dto.ChatbotResponse;
 import com.myjourneylog.service.ChatbotService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RestController
@@ -16,8 +20,8 @@ public class ChatbotController {
     }
 
     @PostMapping("/chatbot")
-    public ResponseEntity<String> generateText(@RequestBody ChatbotRequest request) {
-        String generatedText = chatbotService.getText(request);
+    public ResponseEntity<List<ChatbotResponse>> generateText(@RequestBody ChatbotRequest request) {
+        List<ChatbotResponse> generatedText = chatbotService.getText(request);
         return ResponseEntity.ok(generatedText);
     }
 }

--- a/backend/src/main/java/com/myjourneylog/controller/CourseController.java
+++ b/backend/src/main/java/com/myjourneylog/controller/CourseController.java
@@ -1,0 +1,29 @@
+package com.myjourneylog.controller;
+
+import com.myjourneylog.domain.Course;
+import com.myjourneylog.service.CourseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/course")
+@RequiredArgsConstructor
+public class CourseController {
+
+    private final CourseService courseService;
+
+    @PostMapping("/add")
+    public ResponseEntity<String> saveCourse(@RequestBody List<Course> course) {
+        courseService.addCourse(course);
+        return ResponseEntity.ok("Course added successfully!");
+    }
+
+    @GetMapping("/get")
+    public ResponseEntity<List<Course>> getCourses(@RequestParam Long userId) {
+        List<Course> courses = courseService.getCourses(userId).stream().toList();
+        return ResponseEntity.ok(courses);
+    }
+}

--- a/backend/src/main/java/com/myjourneylog/domain/Course.java
+++ b/backend/src/main/java/com/myjourneylog/domain/Course.java
@@ -2,6 +2,8 @@ package com.myjourneylog.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -11,21 +13,22 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class Course {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "place_id")
-    private Place placeId;
+    private Long userId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User userId;
-
-    private String title;
-    private boolean is_llm_recommended;
-    private LocalDateTime created_at;
+    private String day;
+    private String time;
+    private String recomm;
+    private String description;
+    @Column(name = "is_llm_recommended")
+    private boolean isLlmRecommended;
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/com/myjourneylog/domain/Course.java
+++ b/backend/src/main/java/com/myjourneylog/domain/Course.java
@@ -1,0 +1,31 @@
+package com.myjourneylog.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Course {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private Place placeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User userId;
+
+    private String title;
+    private boolean is_llm_recommended;
+    private LocalDateTime created_at;
+}

--- a/backend/src/main/java/com/myjourneylog/dto/ChatbotResponse.java
+++ b/backend/src/main/java/com/myjourneylog/dto/ChatbotResponse.java
@@ -1,0 +1,13 @@
+package com.myjourneylog.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatbotResponse {
+    private String day;
+    private String time;
+    private String recomm;
+    private String desc;
+}

--- a/backend/src/main/java/com/myjourneylog/dto/CourseDTO.java
+++ b/backend/src/main/java/com/myjourneylog/dto/CourseDTO.java
@@ -5,9 +5,9 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ChatbotResponse {
+public class CourseDTO {
     private String day;
     private String time;
     private String recomm;
-    private String desc;
+    private String description;
 }

--- a/backend/src/main/java/com/myjourneylog/repository/CourseRepository.java
+++ b/backend/src/main/java/com/myjourneylog/repository/CourseRepository.java
@@ -3,5 +3,8 @@ package com.myjourneylog.repository;
 import com.myjourneylog.domain.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CourseRepository extends JpaRepository<Course, Long> {
+    List<Course> findByUserId(Long userId);
 }

--- a/backend/src/main/java/com/myjourneylog/repository/CourseRepository.java
+++ b/backend/src/main/java/com/myjourneylog/repository/CourseRepository.java
@@ -1,0 +1,7 @@
+package com.myjourneylog.repository;
+
+import com.myjourneylog.domain.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+}

--- a/backend/src/main/java/com/myjourneylog/service/ChatbotService.java
+++ b/backend/src/main/java/com/myjourneylog/service/ChatbotService.java
@@ -3,7 +3,8 @@ package com.myjourneylog.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.myjourneylog.dto.ChatbotRequest;
-import com.myjourneylog.dto.ChatbotResponse;
+import com.myjourneylog.dto.CourseDTO;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 @Service
+@RequiredArgsConstructor
 public class ChatbotService {
 
     private final RestTemplate restTemplate;
@@ -30,12 +32,7 @@ public class ChatbotService {
     @Value("${gemini.api-url}")
     private String apiUrl;
 
-    public ChatbotService(RestTemplate restTemplate, ObjectMapper objectMapper) {
-        this.restTemplate = restTemplate;
-        this.objectMapper = objectMapper;
-    }
-
-    public List<ChatbotResponse> getText(ChatbotRequest request) {
+    public List<CourseDTO> getText(ChatbotRequest request) {
         String fullApiUrlString = UriComponentsBuilder.fromUriString(apiUrl)
                 .queryParam("key", apiKey)
                 .build().toUriString();
@@ -66,7 +63,7 @@ public class ChatbotService {
                             jsonResponseText = jsonResponseText.replace("#", "").replace("*", "").replace("`", "");
 
                             return objectMapper.readValue(jsonResponseText,
-                                    objectMapper.getTypeFactory().constructCollectionType(List.class, ChatbotResponse.class));
+                                    objectMapper.getTypeFactory().constructCollectionType(List.class, CourseDTO.class));
                         }
                     }
                 }
@@ -103,7 +100,7 @@ public class ChatbotService {
                 "day": "[일차 (예: 1일차)]",
                 "time": "[시간대 (예: 아침, 점심, 저녁)]",
                 "recomm": "[추천 관광지 1곳 & 추천 맛집 1곳]",
-                "desc": "추천 관광지 설명\\n추천 맛집 설명"
+                "description": "추천 관광지 설명\\n추천 맛집 설명"
               }
               // ... (추가적인 일차 및 시간대별 코스) ...
             ]
@@ -148,9 +145,9 @@ public class ChatbotService {
         chatbotResponseProperties.put("day", Map.of("type", "STRING"));
         chatbotResponseProperties.put("time", Map.of("type", "STRING"));
         chatbotResponseProperties.put("recomm", Map.of("type", "STRING"));
-        chatbotResponseProperties.put("desc", Map.of("type", "STRING"));
+        chatbotResponseProperties.put("description", Map.of("type", "STRING"));
 
-        List<String> chatbotResponseRequired = List.of("day", "time", "recomm", "desc");
+        List<String> chatbotResponseRequired = List.of("day", "time", "recomm", "description");
         Map<String, Object> chatbotResponseSchema = Map.of(
                 "type", "OBJECT",
                 "properties", chatbotResponseProperties,

--- a/backend/src/main/java/com/myjourneylog/service/CourseService.java
+++ b/backend/src/main/java/com/myjourneylog/service/CourseService.java
@@ -1,0 +1,26 @@
+package com.myjourneylog.service;
+
+import com.myjourneylog.domain.Course;
+import com.myjourneylog.repository.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+
+    public void addCourse(List<Course> course) {
+        if (course.isEmpty()) {
+            return;
+        }
+        courseRepository.saveAll(course);
+    }
+
+    public List<Course> getCourses(Long userId) {
+        return courseRepository.findByUserId(userId);
+    }
+}


### PR DESCRIPTION
#8 
## 개요
- 챗봇이 추천해준 코스를 간결하게 만들어서 제공
- 사용자가 선택한 코스를 DB에 저장

## 주요 변경점
- Course 클래스 생성 시 userId를 User -> Long 대체
- Gemini 답변에서 간결한 답변을 받기위한 Prompt 값 추가
- POST /add 선택한 코스와 userId 등 옵션값을 전달하면 DB에 저장

## 테스트
- Postman으로 챗봇 컨디션값 입력 시 추천 코스 제공
- 원하는 코스를 Json 형식으로 넘길 경우 DB에 저장