### PR TITLE
feat : 카카오맵 React 컴포넌트 연동 및 기본 지도 표시

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>카카오맵 테스트</title>
+</head>
+<body>
+<div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,35 +1,12 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import KakaoMap from "./components/KakaoMap";
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    return (
+        <div>
+            <h1 style={{ textAlign: "center", marginTop: 24 }}>Kakao Map</h1>
+            <KakaoMap />
+        </div>
+    );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/KakaoMap.jsx
+++ b/frontend/src/components/KakaoMap.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+
+function KakaoMap() {
+    const mapRef = useRef(null);
+
+    useEffect(() => {
+        if (!window.kakao || !window.kakao.maps) {
+            const script = document.createElement("script");
+            script.src =
+                "https://dapi.kakao.com/v2/maps/sdk.js?appkey=e7cd40de368883583525cde467f28757&autoload=false";
+            script.async = true;
+            document.head.appendChild(script);
+
+            script.onload = () => {
+                window.kakao.maps.load(() => {
+                    drawMap();
+                });
+            };
+        } else {
+            window.kakao.maps.load(() => {
+                drawMap();
+            });
+        }
+
+        function drawMap() {
+            if (!mapRef.current) return;
+            new window.kakao.maps.Map(mapRef.current, {
+                center: new window.kakao.maps.LatLng(37.5665, 126.9780),
+                level: 3,
+            });
+        }
+    }, []);
+
+    return (
+        <div
+            ref={mapRef}
+            style={{
+                width: "90vw",
+                height: "70vh",
+                margin: "32px auto",
+                borderRadius: "16px",
+                boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+                background: "#fff",
+            }}
+        ></div>
+    );
+}
+
+export default KakaoMap;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+ReactDOM.createRoot(document.getElementById("root")).render(
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>
+);


### PR DESCRIPTION
## 개요
- 카카오맵 React 연동 및 지도 표시 기능을 추가했습니다.

## 주요 변경 사항
- 카카오 JavaScript SDK를 프로젝트에 연동
- 서비스 비활성화 이슈 (403 Forbidden) -> 카카오 디벨로퍼스에서 서비스 활성화하여 해결
- '/components/KakaoMap.jsx' 컴포넌트 구현
- App.jsx에서 KakaoMap 컴포넌트 적용 및 UI 스타일 조정

## 확인 방법
- localhost:5173에서 기본 지도 정상 표시되는지 확인
- 콘솔 에러 및 네트워크 에러 발생하지 않는지 체크